### PR TITLE
Switch to using OAuth (untested!)

### DIFF
--- a/src/nexusModsDownloader.ts
+++ b/src/nexusModsDownloader.ts
@@ -118,17 +118,23 @@ async function startDownload(
     const nexusModsModId = gameSupport.nexusMods?.modId;
     const state = api.getState();
     const nexusInfo: any = util.getSafe(state, ['persistent', 'nexus', 'userInfo'], undefined);
-    const APIKEY: string = util.getSafe(state, ['confidential', 'account', 'nexus', 'APIKey'], undefined);
+    // const APIKEY: string = util.getSafe(state, ['confidential', 'account', 'nexus', 'APIKey'], undefined);
+    const OAuthCredentials = (state.confidential.account as any)?.nexus?.OAuthCredentials;
 
     // Free users or logged out users should be directed to the website.
     const modPageURL = `https://www.nexusmods.com/${gameSupport.nexusMods?.gameId}/mods/${gameSupport.nexusMods?.modId}?tab=files`;
     
     // If the user is logged out, all we can do is open the web page.
-    if (!nexusInfo || !APIKEY) return util.opn(modPageURL).catch(() => null);
+    if (!nexusInfo || !OAuthCredentials) return util.opn(modPageURL).catch(() => null);
+
+    const OAuth = {
+        fingerprint: OAuthCredentials.fingerprint,
+        refreshToken: OAuthCredentials.refreshToken,
+        token: OAuthCredentials.token,
+    }
     
     // Use the Nexus Mods API to get the file ID. 
-    const nexus = new Nexus('Vortex', util.getApplication().version, gameId, 30000);
-    await nexus.setKey(APIKEY);
+    const nexus = await Nexus.createWithOAuth(OAuth, { id: 'vortex_loopback', secret: undefined }, 'Vortex', util.getApplication().version, gameId, 30000);
     let fileId: number = -1;
     try {
         const allModFiles = await nexus.getModFiles(nexusModsModId, nexusModsGameId).catch(() => ({ files: [], file_updates: [] }));


### PR DESCRIPTION
What is "secret" when setting up the OAuth? Vortex doesn't use that itself.

Currently the script extender download will never follow the Premium flow because it's checking for an API key rather than the OAuth credentials 